### PR TITLE
Adding a docker-compose that does not require a build.

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -11,7 +11,9 @@ services:
   philter:
     depends_on:
       - ph-eye
-    image: philterd/philter:2.7.1
+    build:
+      context: .
+      dockerfile: Dockerfile.philter
     ports:
       - "8080:8080"
     volumes:


### PR DESCRIPTION
### Description
Adds a docker-compose that does not require a build. It just pulls the images from dockerhub.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
